### PR TITLE
Fix rethrow in TaskScope

### DIFF
--- a/src/Async/TaskScope.cs
+++ b/src/Async/TaskScope.cs
@@ -38,6 +38,7 @@ public sealed class TaskScope
                 case (null, true, not null):
                     throw backgroundException;
                 case (not null, true, _):
+                case (not null, false, null):
                     throw ex;
                 case (not null, false, not null):
                     throw new AggregateException(ex, backgroundException);

--- a/test/AsyncTests.cs
+++ b/test/AsyncTests.cs
@@ -74,4 +74,31 @@ public sealed class AsyncTests
         await backgroundTask;
         await scope;
     }
+
+    [Fact]
+    public Task ExceptionRethrownIfNoBackgroundCanceled()
+    {
+        return Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            Task? backgroundTask = null;
+            var scope = TaskScope.With(scope =>
+            {
+                var backgroundCompleted = new TaskCompletionSource();
+                try
+                {
+                    backgroundTask = scope.Run(async () =>
+                    {
+                        await backgroundCompleted.Task;
+                        _output.WriteLine("Background task completed.");
+                    });
+                    throw new InvalidOperationException("Test");
+                }
+                finally
+                {
+                    backgroundCompleted.SetResult();
+                }
+            });
+            await scope;
+        });
+    }
 }


### PR DESCRIPTION
TaskScope had a bug where if an exception occurred, but the background Tasks all completed normally, the exception wasn't rethrown. This change fixes the problem and adds a test case.