### PR TITLE
Improve exception reporting in TaskScope

### DIFF
--- a/src/Async/StaticCs.Async.csproj
+++ b/src/Async/StaticCs.Async.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>StaticCS.Async</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
TaskScope will now rethrow the original exception, to improve the stack trace for callers.