### PR TITLE
Implement [Closed] support for classes/records

### DIFF
--- a/src/StaticCs.Analyzers/ClosedDeclarationChecker.cs
+++ b/src/StaticCs.Analyzers/ClosedDeclarationChecker.cs
@@ -1,0 +1,94 @@
+
+using System.Collections.Immutable;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security.Claims;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace StaticCs;
+
+[DiagnosticAnalyzer("C#")]
+public sealed class ClosedDeclarationChecker : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor s_descriptor = new(
+            id: DiagId.ClassOrRecordMustBeClosed.ToIdString(),
+            title: "[Closed] is only valid on classes/records with closed hierarchies",
+            messageFormat: "[Closed] is only valid on abstract classes/records with private constructors",
+            category: "StaticCs",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(ctx =>
+        {
+            var node = (AttributeListSyntax)ctx.Node;
+            if (node.Parent is not TypeDeclarationSyntax typeDecl)
+                return;
+            SemanticModel? model = null;
+            foreach (var attr in node.Attributes)
+            {
+                if (!attr.Name.ToFullString().Contains("Closed"))
+                    continue;
+                model ??= ctx.SemanticModel;
+                if (IsClosedAttribute(model.GetTypeInfo(attr).Type) &&
+                    !IsTypeClosed(model.GetDeclaredSymbol(typeDecl)))
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(s_descriptor, attr.GetLocation()));
+                }
+            }
+        }, SyntaxKind.AttributeList);
+
+        // A type is considered "closed" if it is an enum or it is an abstract class or record with no non-private constructors.
+        static bool IsTypeClosed(INamedTypeSymbol? type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+            if (type is not { TypeKind: TypeKind.Class })
+            {
+                return false;
+            }
+
+            if (!type.IsAbstract)
+            {
+                return false;
+            }
+
+            foreach (var ctor in type.InstanceConstructors)
+            {
+                // Skip copy constructor
+                if (ctor.Parameters.Length == 1 && ctor.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default))
+                {
+                    continue;
+                }
+                if (ctor.DeclaredAccessibility != Accessibility.Private)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public static bool IsClosedAttribute(ITypeSymbol? type)
+    {
+        return type is {
+            Name: "ClosedAttribute",
+            ContainingNamespace: {
+                Name: "StaticCs",
+                ContainingNamespace: {
+                    IsGlobalNamespace: true
+                }
+            }
+        };
+    }
+}

--- a/src/StaticCs.Analyzers/DiagId.cs
+++ b/src/StaticCs.Analyzers/DiagId.cs
@@ -1,13 +1,14 @@
 
 namespace StaticCs;
 
-internal enum DiagId
+public enum DiagId
 {
     ClosedEnumConversion = 1,
-    SwitchOnClosedSuppress = 2
+    SwitchOnClosedSuppress = 2,
+    ClassOrRecordMustBeClosed = 3,
 }
 
-internal static class DiagUtils
+public static class DiagUtils
 {
     private const string DiagPrefix = "STATICCS";
 

--- a/src/StaticCs.Analyzers/EnumClosedConversionAnalyzer.cs
+++ b/src/StaticCs.Analyzers/EnumClosedConversionAnalyzer.cs
@@ -10,8 +10,8 @@ namespace StaticCs;
 [DiagnosticAnalyzer("C#")]
 public sealed class EnumClosedConversionAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(
-            id: DiagId.SwitchOnClosedSuppress.ToIdString(),
+    public static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(
+            id: DiagId.ClosedEnumConversion.ToIdString(),
             title: "Integers cannot be converted to [Closed] enums",
             messageFormat: "Integer conversions to [Closed] enum {0} are disallowed",
             category: "StaticCs",

--- a/src/StaticCs.Analyzers/StaticCs.Analyzers.csproj
+++ b/src/StaticCs.Analyzers/StaticCs.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>StaticCS</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/StaticCs.ContentFiles/ClosedAttribute.cs
+++ b/src/StaticCs.ContentFiles/ClosedAttribute.cs
@@ -3,6 +3,6 @@ using System;
 
 namespace StaticCs
 {
-    [AttributeUsage(AttributeTargets.Enum)]
+    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class)]
     internal sealed class ClosedAttribute : Attribute { }
 }

--- a/test/ClosedTests.cs
+++ b/test/ClosedTests.cs
@@ -1,5 +1,296 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Xunit;
+
+namespace StaticCs.Tests;
+
+public class ClosedTests
+{
+    [Fact]
+    public async Task WarningOnOpenEnum()
+    {
+        var src = """
+enum Rgb { Red, Green, Blue }
+
+class C
+{
+    int M(Rgb rgb) => rgb switch
+    {
+        Rgb.Red => 0,
+        Rgb.Green => 1,
+        Rgb.Blue => 2,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(5,27): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Rgb)3' is not covered.
+            DiagnosticResult.CompilerWarning("CS8524").WithSpan(5, 27, 5, 33).WithArguments("(Rgb)3"));
+    }
+
+    [Fact]
+    public async Task SuppressedOnClosedEnum()
+    {
+        var src = """
+[StaticCs.Closed]
+enum Rgb { Red, Green, Blue }
+
+class C
+{
+    int M(Rgb rgb) => rgb switch
+    {
+        Rgb.Red => 0,
+        Rgb.Green => 1,
+        Rgb.Blue => 2,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(6,27): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Rgb)3' is not covered.
+            DiagnosticResult.CompilerWarning("CS8524").WithSpan(6, 27, 6, 33).WithArguments("(Rgb)3").WithIsSuppressed(true));
+    }
+
+    [Fact]
+    public async Task ExplicitConversionToClosedError()
+    {
+        var src = """
+using System;
+
+[StaticCs.Closed]
+enum Rgb { Red, Green, Blue }
+class C
+{
+    void M()
+    {
+        Rgb rgb = (Rgb)10;
+        Console.WriteLine(rgb);
+    }
+}
+""";
+        await VerifyDiagnostics<EnumClosedConversionAnalyzer>(src,
+            // /0/Test0.cs(9,19): error STATICCS002: Integer conversions to [Closed] enum Rgb are disallowed
+            ClosedEnumConversion.WithSpan(9, 19, 9, 26).WithArguments("Rgb"));
+    }
+
+    [Fact]
+    public async Task ImplicitConversionToClosedLoophole()
+    {
+        var src = """
+using System;
+
+[StaticCs.Closed]
+enum Rgb { Red, Green, Blue }
+class C
+{
+    void M()
+    {
+        Rgb rgb = 0;
+        Console.WriteLine(rgb);
+    }
+}
+""";
+        await VerifyDiagnostics<EnumClosedConversionAnalyzer>(src);
+    }
+
+    [Fact]
+    public async Task ClosedOnNonAbstractClass()
+    {
+        var src = """
+[StaticCs.Closed]
+class Base
+{ }
+""";
+        await VerifyDiagnostics<ClosedDeclarationChecker>(src,
+            // /0/Test0.cs(1,2): error STATICCS003: [Closed] is only valid on abstract classes/records with private constructors
+            ClassOrRecordMustBeClosed.WithSpan(1, 2, 1, 17));
+    }
+
+    [Fact]
+    public async Task ClosedOnAbstractClassWithPublicConstructor()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract class Base { }
+""";
+        await VerifyDiagnostics<ClosedDeclarationChecker>(src,
+            // /0/Test0.cs(1,2): error STATICCS003: [Closed] is only valid on abstract classes/records with private constructors
+            ClassOrRecordMustBeClosed.WithSpan(1, 2, 1, 17));
+    }
+
+    [Fact]
+    public async Task ClosedOnAbstractClassWithPrivateConstructor()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract class Base
+{
+    private Base() { }
+}
+""";
+        await VerifyDiagnostics<ClosedDeclarationChecker>(src);
+    }
+
+    [Fact]
+    public async Task ClosedOnAbstractRecordWithPrivateConstructor()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Base
+{
+    private Base() { }
+}
+""";
+        await VerifyDiagnostics<ClosedDeclarationChecker>(src);
+    }
+
+    [Fact]
+    public async Task WarningOnOpenRecord()
+    {
+        var src = """
+abstract record Base
+{
+    public record A : Base;
+    public record B : Base;
+}
+class C
+{
+    int M(Base b) => b switch
+    {
+        Base.A => 0,
+        Base.B => 1,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(8,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(8, 24, 8, 30).WithArguments("_"));
+    }
+
+    [Fact]
+    public async Task SuppressedWarningOnClosedRecord()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Base
+{
+    private Base() { }
+    public record A : Base;
+    public record B : Base;
+}
+class C
+{
+    int M(Base b) => b switch
+    {
+        Base.A => 0,
+        Base.B => 1,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(10,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 24, 10, 30).WithArguments("_").WithIsSuppressed(true));
+    }
+
+    [Fact]
+    public async Task ClosedRecordMissingCase()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Base
+{
+    private Base() { }
+    public record A : Base;
+    public record B : Base;
+}
+class C
+{
+    int M(Base b) => b switch
+    {
+        Base.A => 0,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(10,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 24, 10, 30).WithArguments("_"));
+    }
+
+    [Fact]
+    public async Task ClosedRecordDeconstruct()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Option<T>
+{
+    private Option() { }
+    public record Some(T Value) : Option<T>;
+    public record None : Option<T>;
+}
+class C
+{
+    int M(Option<int> b) => b switch
+    {
+        Option<int>.Some(int i) => i,
+        Option<int>.None => 1,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(10,31): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 31, 10, 37).WithArguments("_").WithIsSuppressed(true));
+    }
+
+    [Fact]
+    public async Task ClosedRecordRefutable()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Option<T>
+{
+    private Option() { }
+    public record Some(T Value) : Option<T>;
+    public record None : Option<T>;
+}
+class C
+{
+    int M(Option<int> b) => b switch
+    {
+        Option<int>.Some(5) => 5,
+        Option<int>.None => 1,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(10,31): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern 'Option<int>.Some(0) { }' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 31, 10, 37).WithArguments("Option<int>.Some(0) { }"));
+    }
+
+    private static readonly DiagnosticResult ClosedEnumConversion = CSharpAnalyzerVerifier<EnumClosedConversionAnalyzer, XUnitVerifier>.Diagnostic(DiagId.ClosedEnumConversion.ToIdString());
+    private static readonly DiagnosticResult ClassOrRecordMustBeClosed = CSharpAnalyzerVerifier<ClosedDeclarationChecker, XUnitVerifier>.Diagnostic(DiagId.ClassOrRecordMustBeClosed.ToIdString());
+
+    private Task VerifyDiagnostics<TAnalyzer>(string src, params DiagnosticResult[] expected) where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        var test = new CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+        {
+            TestCode = src,
+            CompilerDiagnostics = CompilerDiagnostics.Warnings,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+        };
+        test.TestState.Sources.Add(
+            File.ReadAllText(Path.Combine(CurrentPath(), "../../src/StaticCs.ContentFiles/ClosedAttribute.cs")));
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    private static string CurrentPath([CallerFilePath] string? path = null) => path ?? throw new InvalidOperationException();
+}
 //using System;
 //using StaticCs;
 //

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -18,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\src\Collections\StaticCs.Collections.csproj" />
     <ProjectReference Include="../src/Async/StaticCs.Async.csproj" />
+    <ProjectReference Include="../src/StaticCs.Analyzers/StaticCs.Analyzers.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The rules for types are:

  1. The annotated type must be abstract
  2. It must only have private constructors, except the record copy constructor

The support on the switch expression side is fairly simple. Type checking every nested type is enough to get rid of the incompleteness warning. You can also include a positional pattern where the arguments are either exact type matches, or var, or discards.