### PR TITLE
Accept DeclarationPattern as irrefutable

### DIFF
--- a/src/StaticCs.Analyzers/ClosedTypeCompletenessSuppressor.cs
+++ b/src/StaticCs.Analyzers/ClosedTypeCompletenessSuppressor.cs
@@ -71,6 +71,14 @@ public class ClosedTypeCompletenessSuppressor : DiagnosticSuppressor
                                     subTypes.Remove(namedType);
                                 }
                             }
+                            else if (arm.Pattern is DeclarationPatternSyntax { Type: { } patternSyntax })
+                            {
+                                var symbolInfo = model.GetSymbolInfo(patternSyntax);
+                                if (symbolInfo.Symbol is INamedTypeSymbol namedType)
+                                {
+                                    subTypes.Remove(namedType);
+                                }
+                            }
                             else if (arm.Pattern is RecursivePatternSyntax
                             {
                                 Type: { } patternTypeSyntax,

--- a/src/StaticCs.Analyzers/StaticCs.Analyzers.csproj
+++ b/src/StaticCs.Analyzers/StaticCs.Analyzers.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>StaticCS</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/test/ClosedTests.cs
+++ b/test/ClosedTests.cs
@@ -272,6 +272,31 @@ class C
             DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 31, 10, 37).WithArguments("Option<int>.Some(0) { }"));
     }
 
+    [Fact]
+    public async Task ClosedRecordTypeTestWithVariable()
+    {
+        var src = """
+[StaticCs.Closed]
+abstract record Base
+{
+    private Base() { }
+    public record A : Base;
+    public record B : Base;
+}
+class C
+{
+    int M(Base b) => b switch
+    {
+        Base.A a => a.GetHashCode(),
+        Base.B => 1,
+    };
+}
+""";
+        await VerifyDiagnostics<ClosedTypeCompletenessSuppressor>(src,
+            // /0/Test0.cs(10,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '_' is not covered.
+            DiagnosticResult.CompilerWarning("CS8509").WithSpan(10, 24, 10, 30).WithArguments("_").WithIsSuppressed(true));
+    }
+
     private static readonly DiagnosticResult ClosedEnumConversion = CSharpAnalyzerVerifier<EnumClosedConversionAnalyzer, XUnitVerifier>.Diagnostic(DiagId.ClosedEnumConversion.ToIdString());
     private static readonly DiagnosticResult ClassOrRecordMustBeClosed = CSharpAnalyzerVerifier<ClosedDeclarationChecker, XUnitVerifier>.Diagnostic(DiagId.ClassOrRecordMustBeClosed.ToIdString());
 


### PR DESCRIPTION
Allows a DeclarationPatternSyntax when switching against a Closed class